### PR TITLE
Avoid tight_layout matplotlib option

### DIFF
--- a/scripts/DQMReader.py
+++ b/scripts/DQMReader.py
@@ -6,12 +6,11 @@
 import os, string, sys, posix, tokenize, array, getopt,struct
 import numpy as np
 import pylab as P
+import matplotlib as mpl
 import matplotlib.mlab as mlab
 import matplotlib.pyplot as plt
 
 def main(argv):
-
-
     # AcquisitionMode
     CONT_STORAGE=0
     TRIG_MATCH=1
@@ -36,13 +35,21 @@ def main(argv):
     occupancy = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
     toverthreshold = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
     nerrors = [0]
+    grouperrors = [0,0,0,0]
+    readoutfifooverflowerrors = [0,0,0,0]
+    l1bufferoverflowerrors = [0,0,0,0]
+    eventsizelimiterrors = [0]
+    triggerfifooverflowerrors = [0]
+    internalchiperrors = [0]
     ntriggers = [0]
     nchannels = 16
     verbose = 0
 
     # Open as a readable binary file - hardcoded for testing 
     with open('events_board0.dat', 'rb') as f:
-        # First read and unpack the file header 
+        #######################################
+        # First read and unpack the file header
+        #######################################
         byte = f.read(24)
         decode = struct.unpack("IIIBII",byte[:24])
         magic = decode[0]
@@ -64,13 +71,15 @@ def main(argv):
         # Lookup dictionary of time measurements: time = {Channel ID, Leading/Trailing edge}
         channeltimemeasurements={}
 
-        # Now loop over the data
+        ###########################                                                                                                                                              
+        # Main loop to read in data
+        ###########################
         while(f.read(1)):
             f.seek(-1,1) # Stupid python tricks - read ahead 1 byte to check for eof
 
             # Read and decode the "type" of this word. The type will determine what other information is present
             decode = struct.unpack("I",f.read(4))
-            type = ((decode[0])>>27)&(0x1F)
+            type = ((decode[0]) >> 27) & (0x1F)
 
             if(type == GlobalHeader):
                 if(verbose == 1):
@@ -78,17 +87,18 @@ def main(argv):
                 # Reset lookup dictionary for each new event
                 channeltimemeasurements={}
 
+            # This word is a global trailer - calculate summary timing information for all channels in this event
             if(type == GlobalTrailer):
-                status = ((decode[0])>>24)&(0x7)
+                status = ((decode[0]) >> 24) & (0x7)
                 if(verbose == 1):
                     print "\tTiming measurements for this trigger:"
                     print"\t\tChannel\tLeading\t\tTrailing\tDifference"
                 channelflag=0
                 while channelflag < nchannels:
-                    tleading = channeltimemeasurements[channelflag,1]*25./1024.
-                    ttrailing = channeltimemeasurements[channelflag,2]*25./1024.
-                    tdifference = (channeltimemeasurements[channelflag,2]-channeltimemeasurements[channelflag,1])*25./1024.
-                    toverthreshold[channelflag] = toverthreshold[channelflag]+tdifference
+                    tleading = channeltimemeasurements[channelflag,1] * 25./1024.
+                    ttrailing = channeltimemeasurements[channelflag,2] * 25./1024.
+                    tdifference = (channeltimemeasurements[channelflag,2] - channeltimemeasurements[channelflag,1]) * 25./1024.
+                    toverthreshold[channelflag] = toverthreshold[channelflag] + tdifference
                     if(verbose == 1):
                         print "\t\t" + str(channelflag) + ":\t" + str(tleading) + ",\t" + str(ttrailing) + ",\t" + str(tdifference)
                         print "Global Trailer (status = " + str(status) +")"
@@ -103,18 +113,19 @@ def main(argv):
                     print "HEY!!!!!!!!!!! TDCTrailer!!!!!!!!!!"
 
             if(type == ETTT):
-                GetETT = (decode[0])&(0x3FFFFFF)
+                GetETT = (decode[0]) & (0x3FFFFFF)
                 if(verbose == 1):
                     print "ETT = " + str(GetETT)
-                ntriggers[0] = ntriggers[0]+1
+                ntriggers[0] = ntriggers[0] + 1
 
+            # This word is an actual TDC measurement - get the timing and leading/trailing edge informations
             if(type == TDCMeasurement):
-                istrailing = ((decode[0])>>26)&(0x1)
-                time = (decode[0])&(0x7FFFF)
+                istrailing = ((decode[0]) >> 26) & (0x1)
+                time = (decode[0]) & (0x7FFFF)
                 if(DetectionMode == PAIR):
-                    time = (decode[0])&(0xFFF)
-                width = ((decode[0])>>12)&(0x7F)
-                channelid = ((decode[0])>>21)&(0x1F)
+                    time = (decode[0]) & (0xFFF)
+                width = ((decode[0]) >> 12) & (0x7F)
+                channelid = ((decode[0]) >> 21) & (0x1F)
 
                 if(istrailing == 0):
                     channeltimemeasurements[channelid,1] = time
@@ -124,9 +135,24 @@ def main(argv):
                 if(verbose == 1):
                     print "\tTDCMeasurement (trailing = " + str(istrailing) + ", time = " + str(time) + ", width = " + str(width) + ", (channel ID = " + str(channelid) + ")"
                 
+            # This word is and Error - decode and count each type of error
             if(type == TDCError):
-                errorflag = (decode[0])&(0x7FFF)
-                nerrors[0] = nerrors[0]+1
+                errorflag = (decode[0]) & (0x7FFF)
+                nerrors[0] = nerrors[0] + 1
+                if(((decode[0]) >> 12) & 0x1):
+                    eventsizelimiterrors[0] = eventsizelimiterrors[0] + 1
+                if(((decode[0]) >> 13) & 0x1):
+                    triggerfifooverflowerrors[0] = triggerfifooverflowerrors[0] + 1
+                if(((decode[0]) >> 14) & 0x1):
+                    internalchiperrors[0] = internalchiperrors[0] +1
+                j = 0
+                while j < 4:
+                    if(((decode[0]) >> (2+3*j)) & 0x1):
+                        grouperrors[j] = grouperrors[j] + 1
+                    if(((decode[0]) >> (1+3*j)) & 0x1):
+                        l1bufferoverflowerrors[j] = l1bufferoverflowerrors[j] + 1
+                    if(((decode[0]) >> (3*j)) & 0x1):
+                        readoutfifooverflowerrors[j] = readoutfifooverflowerrors[j] + 1
                 if(verbose == 1):
                     print "Error detected: " + str(errorflag)
 
@@ -140,35 +166,39 @@ def main(argv):
         occupancy[i] = occupancy[i]/ntriggers[0]
         i = i + 1
 
-    plt.subplot(2, 2, 1)
+    mpl.rcParams['xtick.labelsize'] = 6
+    mpl.rcParams['ytick.labelsize'] = 6
+
+    plt.subplot(3, 3, 1)
     plt.bar(range(0,1),ntriggers,width=1.0)
-    plt.ylabel('Number of triggered events')
-    plt.title(r'$\mathrm{Number\ of\ triggered\ events}$')
-    plt.axis([0, 1, 0, max(ntriggers)*2])
+    plt.ylabel('Triggered events',fontsize=6)
+#    plt.title(r'$\mathrm{Number\ of\ triggered\ events}$',fontsize=6)
+    plt.figtext(0.15, 0.8, "N = " + str(ntriggers[0]))
+    plt.axis([0, 1, 0, max(ntriggers)*2],fontsize=6)
     frame1 = plt.gca()
     frame1.axes.get_xaxis().set_visible(False)
     plt.grid(True)
 
-    plt.subplot(2, 2, 2)
+    plt.subplot(3, 3, 2)
     plt.bar(range(0,nchannels),occupancy)
-    plt.xlabel('HPTDC Channel')
-    plt.ylabel('Occupancy per trigger')
-    plt.title(r'$\mathrm{HPTDC\ Channel\ occupancy}$')
-    plt.axis([0, nchannels, 0, 1.2])
+    plt.xlabel('HPTDC Channel',fontsize=6)
+    plt.ylabel('Occupancy',fontsize=6)
+#    plt.title(r'$\mathrm{HPTDC\ Channel\ occupancy}$',fontsize=6)
+    plt.axis([0, nchannels, 0, 1.2],fontsize=6)
     plt.grid(True)
 
-    plt.subplot(2, 2, 3)
+    plt.subplot(3, 3, 3)
     plt.bar(range(0,nchannels),toverthreshold)
-    plt.xlabel('HPTDC Channel')
-    plt.ylabel('Mean time over threshold [ns]')
-    plt.title(r'$\mathrm{Mean\ time\ over\ threshold\ per\ channel}$')
+    plt.xlabel('HPTDC Channel',fontsize=6)
+    plt.ylabel('Mean time over threshold [ns]',fontsize=6)
+#    plt.title(r'$\mathrm{Mean\ time\ over\ threshold}$',fontsize=6)
     plt.axis([0, nchannels, 0, max(toverthreshold)*2])
     plt.grid(True)
 
-    plt.subplot(2, 2, 4)
+    plt.subplot(3, 3, 4)
     plt.bar(range(0,1),nerrors,width=1.0)
-    plt.ylabel('Number of errors')
-    plt.title(r'$\mathrm{Number\ of\ errors}$')
+    plt.ylabel('Total errors',fontsize=6)
+#    plt.title(r'$\mathrm{Total\ errors}$',fontsize=6)
     plt.axis([0, 1, 0, 2])
     if(nerrors[0]>0):
         plt.axis([0, 1, 0, max(nerrors)*2])
@@ -176,9 +206,65 @@ def main(argv):
     frame2.axes.get_xaxis().set_visible(False)
     plt.grid(True)
 
-    plt.tight_layout() # Or equivalently,  "plt.tight_layout()"                                        
 #    plt.show()
-    plt.savefig('testfig1.png')
+#    plt.savefig('testfig1.png')
 
+    plt.subplot(3, 3, 5)
+    plt.bar(range(0,1),eventsizelimiterrors,width=1.0)
+    plt.ylabel('Event size errors',fontsize=6)
+#    plt.title(r'$\mathrm{Event\ size\ errors}$',fontsize=6)
+    plt.axis([0, 1, 0, 2])
+    if(eventsizelimiterrors[0]>0):
+        plt.axis([0, 1, 0, max(eventsizelimiterrors)*2])
+    frame2 = plt.gca()
+    frame2.axes.get_xaxis().set_visible(False)
+    plt.grid(True)
+
+    plt.subplot(3, 3, 6)
+    plt.bar(range(0,1),triggerfifooverflowerrors,width=1.0)
+    plt.ylabel('Trigger FIFO overflow errors',fontsize=6)
+#    plt.title(r'$\mathrm{Trigger\ FIFO\ overflow\ errors}$',fontsize=6)
+    plt.axis([0, 1, 0, 2])
+    if(triggerfifooverflowerrors[0]>0):
+        plt.axis([0, 1, 0, max(triggerfifooverflowerrors)*2])
+    frame2 = plt.gca()
+    frame2.axes.get_xaxis().set_visible(False)
+    plt.grid(True)
+
+    plt.subplot(3, 3, 7)
+    plt.bar(range(0,1),internalchiperrors,width=1.0)
+    plt.ylabel('Internal chip errors',fontsize=6)
+#    plt.title(r'$\mathrm{Internal\ chip\ errors}$',fontsize=6)
+    plt.axis([0, 1, 0, 2])
+    if(internalchiperrors[0]>0):
+        plt.axis([0, 1, 0, max(internalchiperrors)*2])
+    frame2 = plt.gca()
+    frame2.axes.get_xaxis().set_visible(False)
+    plt.grid(True)
+
+    plt.subplot(3, 3, 8)
+    plt.bar(range(0,4),readoutfifooverflowerrors)
+    plt.ylabel('Readout FIFO overflow errors',fontsize=6)
+    plt.xlabel('Group',fontsize=6)
+#   plt.title(r'$\mathrm{Readout\ FIFO\ overflow\ errors}$',fontsize=6)
+    plt.axis([0, 4, 0, 2])
+    if(readoutfifooverflowerrors[0]>0):
+        plt.axis([0, 4, 0, max(readoutfifooverflowerrors)*2])
+    frame2 = plt.gca()
+    plt.grid(True)
+
+    plt.subplot(3, 3, 9)
+    plt.bar(range(0,4),l1bufferoverflowerrors)
+    plt.ylabel('L1 buffer overflow errors',fontsize=6)
+    plt.xlabel('Group',fontsize=6)
+#    plt.title(r'$\mathrm{L1\ buffer\ overflow\ errors}$',fontsize=6)
+    plt.axis([0, 4, 0, 2])
+    if(l1bufferoverflowerrors[0]>0):
+        plt.axis([0, 4, 0, max(l1bufferoverflowerrors)*2])
+    frame2 = plt.gca()
+    plt.grid(True)
+
+    plt.savefig('testfig2.pdf')
+    
 if __name__ == "__main__":
     main(sys.argv[1:])


### PR DESCRIPTION
Remove "tight_layout" option unavailable in older matplotlib versions and adjust fonts accordingly to fit. Tested on lxplus (which the spell check in github/safari tries to change into "lipless") with python2.7/CMSSW_7X environment setup. Still needs more work on cosmetics...

Also add plots for counting various specific HPTDC error messages, in addition to total # of errors
