### PR TITLE
Several minor changes to DQMReader.py and dqmer.py (default values and filename methods)

### DIFF
--- a/scripts/DQMReader.py
+++ b/scripts/DQMReader.py
@@ -19,9 +19,12 @@ class DQMReader:
         #########################
 
         # Input filename obtined from the server communication. Output file has the same name except for extension
+        if(input.find(".dat") == -1):
+            print "File sent to DQM is not in .dat format - exiting"
+            return
         self.inputbinaryfile = input
-        self.outputplotfile = self.inputbinaryfile.split('.')[0] + '_dqm_report.svg'
-        self.outputtextfile = self.inputbinaryfile.split('.')[0] + '_dqm_report.txt'
+        self.outputplotfile = self.inputbinaryfile.split('.dat')[0] + '_dqm_report.svg'
+        self.outputtextfile = self.inputbinaryfile.split('.dat')[0] + '_dqm_report.txt'
         self.nchannels = 32
         self.ngroups = 4
         self.verbose = 0

--- a/scripts/DQMReader.py
+++ b/scripts/DQMReader.py
@@ -4,13 +4,14 @@
 # Based on https://github.com/forthommel/pps-tbrc/src/FileReader.cpp C++ version by L. Forthomme
 
 import os, string, sys, posix, tokenize, array, getopt, struct, ast
+import matplotlib
+matplotlib.use("Agg")
 import numpy as np
 import pylab as P
 import matplotlib as mpl
 import matplotlib.mlab as mlab
 import matplotlib.pyplot as plt
 
-#def main(argv):
 class DQMReader:
     def __init__(self,input):
         #########################
@@ -21,8 +22,8 @@ class DQMReader:
         self.inputbinaryfile = input
         self.outputplotfile = self.inputbinaryfile.split('.')[0] + '_dqm_report.svg'
         self.outputtextfile = self.inputbinaryfile.split('.')[0] + '_dqm_report.txt'
-        self.nchannels = 64
-        self.ngroups = 16
+        self.nchannels = 32
+        self.ngroups = 4
         self.verbose = 0
         
         ###################                                                                                                                                            
@@ -84,6 +85,12 @@ class DQMReader:
 
     def SetOutputFileFormat(self,extension):
         self.outputplotfile = self.outputplotfile.split('.')[0] + '.' + str(extension)
+
+    def SetInputFilename(self,infname):
+        self.inputbinaryfile = infname
+
+    def SetOutputFilename(self,outfname):
+        self.outputplotfile = outfname
 
     def GetOutputFilename(self):
         return self.outputplotfile

--- a/test/dqmer.py
+++ b/test/dqmer.py
@@ -45,7 +45,6 @@ def run_dqm_process( messenger_socket, computation_process = dummy_computing ):
         tokens = incomming_message.split(":")
 
         # COMPUTE
-        #        if len(tokens) == 2 and tokens[0] == "DQM":
         if len(tokens) == 2 and tokens[0] == "NEW_FILENAME":
             result_filename = computation_process( tokens[1] )
         else:
@@ -55,7 +54,6 @@ def run_dqm_process( messenger_socket, computation_process = dummy_computing ):
 
         # SEND
         try :
-            #            messenger_socket.sendall( "DQM_DONE:" + result_filename )
             messenger_socket.sendall( "NEW_DQM_PLOT:" + result_filename )
         except socket.error:
             #Send failed
@@ -64,5 +62,5 @@ def run_dqm_process( messenger_socket, computation_process = dummy_computing ):
 
 if __name__ == '__main__':
     host = "localhost"
-    socket_to_messenger = make_client( host, 38765 )
+    socket_to_messenger = make_client( host, 1987 )
     run_dqm_process( socket_to_messenger )


### PR DESCRIPTION
Several minor changes - github claims these can be automatically merged despite being 52 commits 
behind and 1 commit ahead of forthommel/pps-tbrc:
- Add SetInput/Output filename hooks to DQMReader. 
- Set default port number in dqmer to 1987 
- Set default # of channels in DQM histograms back to 32, following explanation from Laurent about 
  different output files for each TDC
- Blowup the #@^%\* dancing rocketship icon when using python graphics libraries on a Mac
